### PR TITLE
Replace RPi.GPIO in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   'psutil',
   'adafruit-circuitpython-neopixel-spi',
   'Adafruit-Blinka==8.59.0',
-  'RPi.GPIO',
+  'rpi-lgpio',
 ]
 
 [project.scripts]


### PR DESCRIPTION
`RPi.GPIO` has been replaced in the rest of the code with `rpi-lgpio`, except in the pyproject file. This caused build errors on other platforms. Changing it to match the actual dependency of `rpi-lgpio` fixed the build issue