### PR TITLE
feat(cli): add update, uninstall subcommands and bash auto-completion

### DIFF
--- a/docs/superpowers/plans/2026-05-27-cli-enhancements-plan.md
+++ b/docs/superpowers/plans/2026-05-27-cli-enhancements-plan.md
@@ -1,0 +1,247 @@
+# CLI Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `update`/`uninstall` subcommands and bash auto-completion (argcomplete) to the pironman5 CLI.
+
+**Architecture:** `update` delegates to the canonical install.sh via curl-to-bash. `uninstall` implements removal logic directly in-process. argcomplete hooks into the existing argparse parser for zero-config completions.
+
+**Tech Stack:** Python 3.7+, argparse + argcomplete, bash (install.sh)
+
+---
+
+### Task 1: Add `pironman5 update` subcommand
+
+**Files:**
+- Modify: `pironman5/_cli.py`
+
+- [ ] **Step 1: Add update subparser**
+
+In `main()`, after the `launch-browser` subparser block (line 111), before the comment `# parse args`, insert:
+
+```python
+    update_parser = subparsers.add_parser("update", help="Update Pironman5 to latest version")
+    update_parser.add_argument("--variant", nargs='?', default='', help="Override variant (base/mini/max/pro-max/ups/nas)")
+    update_parser.add_argument("--pipower5", action="store_true", help="Include PiPower5 support")
+```
+
+- [ ] **Step 2: Add update handler in subcommand dispatch**
+
+In `main()`, after the `pipower5` handler block (ending with `sys.exit(1)` at line 608), before the comment `# Update settings`, insert:
+
+```python
+    # update
+    # ----------------------------------------
+    if args.subcommand == 'update':
+        variant = args.variant if args.variant else ''
+        if not variant:
+            try:
+                with open('/opt/pironman5/.variant', 'r') as f:
+                    variant = f.read().strip()
+            except FileNotFoundError:
+                print("Error: Cannot detect variant. /opt/pironman5/.variant not found.")
+                print("Specify variant manually: pironman5 update --variant base")
+                sys.exit(1)
+
+        if not variant:
+            print("Error: Empty variant. Specify manually: pironman5 update --variant base")
+            sys.exit(1)
+
+        use_pipower5 = args.pipower5
+        if not use_pipower5:
+            try:
+                with open('/opt/pironman5/.custom_module', 'r') as f:
+                    if 'pipower5' in f.read():
+                        use_pipower5 = True
+            except FileNotFoundError:
+                pass
+
+        installer_url = "https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/main/pironman5/install.sh"
+        cmd_parts = ["curl -sSL", installer_url, "| sudo bash -s -- --variant", variant, "--plain-text"]
+        if use_pipower5:
+            cmd_parts.append("--pipower5")
+
+        cmd = ' '.join(cmd_parts)
+        print(f"Updating Pironman 5 ({variant})...")
+        print(f"Running: {cmd}")
+        ret = os.system(cmd)
+        if ret != 0:
+            print(f"Update failed with exit code {ret}", file=sys.stderr)
+            sys.exit(1)
+        print("Update complete. Restarting service...")
+        os.system('systemctl restart pironman5.service')
+        quit()
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pironman5/_cli.py
+git commit -m "feat(cli): add update subcommand
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add `pironman5 uninstall` subcommand
+
+**Files:**
+- Modify: `pironman5/_cli.py`
+
+- [ ] **Step 1: Add uninstall subparser**
+
+In `main()`, after the `update_parser` block added in Task 1, before `# parse args`, insert:
+
+```python
+    uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall Pironman5 completely")
+    uninstall_parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts")
+```
+
+- [ ] **Step 2: Add uninstall handler in subcommand dispatch**
+
+In `main()`, after the update handler added in Task 1, before `# Update settings`, insert:
+
+```python
+    # uninstall
+    # ----------------------------------------
+    if args.subcommand == 'uninstall':
+        def _confirm(prompt):
+            if args.yes:
+                return True
+            while True:
+                resp = input(prompt + " [y/N] ")
+                if resp.lower() in ('y', 'yes'):
+                    return True
+                elif resp.lower() in ('', 'n', 'no'):
+                    return False
+
+        if not _confirm("This will completely remove Pironman 5 and all its data. Continue?"):
+            print("Uninstall cancelled.")
+            quit()
+
+        print("Stopping service...")
+        os.system('systemctl stop pironman5.service 2>/dev/null')
+        os.system('systemctl disable pironman5.service 2>/dev/null')
+        service_file = '/etc/systemd/system/pironman5.service'
+        if os.path.exists(service_file):
+            os.remove(service_file)
+            os.system('systemctl daemon-reload')
+
+        print("Removing symlinks...")
+        symlink_path = '/usr/local/bin/pironman5'
+        if os.path.exists(symlink_path):
+            os.remove(symlink_path)
+
+        print("Removing user and group...")
+        os.system('userdel pironman5 2>/dev/null')
+        os.system('groupdel pironman5 2>/dev/null')
+
+        print("Removing directories...")
+        os.system('rm -rf /opt/pironman5/')
+        os.system('rm -rf /var/log/pironman5/')
+
+        if _confirm("Uninstall InfluxDB database too?"):
+            os.system('apt-get purge influxdb -y')
+
+        print("Pironman 5 has been uninstalled.")
+        quit()
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pironman5/_cli.py
+git commit -m "feat(cli): add uninstall subcommand
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add argcomplete auto-completion
+
+**Files:**
+- Modify: `pyproject.toml`
+- Modify: `pironman5/_cli.py`
+- Modify: `../sunfounder-installer-scripts/pironman5/install.sh`
+
+- [ ] **Step 1: Add argcomplete to pyproject.toml dependencies**
+
+Replace:
+```toml
+dependencies = []
+```
+with:
+```toml
+dependencies = [
+    "argcomplete",
+]
+```
+
+- [ ] **Step 2: Add argcomplete setup to _cli.py**
+
+Add as the very first line (line 1, before existing imports):
+```python
+# PYTHON_ARGCOMPLETE_OK
+```
+
+Add to the imports block (line 5 area):
+```python
+import argcomplete
+```
+
+After all subparsers are registered (after `uninstall_parser` from Task 2) and before `# parse args` (line ~115), insert:
+```python
+    argcomplete.autocomplete(parser)
+```
+
+- [ ] **Step 3: Add argcomplete registration to install.sh**
+
+In `F:\workspace\sunfounder-installer-scripts\pironman5\install.sh`, after the pironman5 symlink creation (line 340):
+```bash
+RUN "ln -sf /opt/pironman5/venv/bin/pironman5 /usr/local/bin/pironman5" "Create pironman5 symlink"
+```
+
+Insert after that `RUN` line:
+```bash
+# --- Shell completion ---
+TITLE "Setup shell completion"
+RUN "register-python-argcomplete pironman5 > /etc/bash_completion.d/pironman5" "Register bash completion"
+```
+
+- [ ] **Step 4: Verify argcomplete imports**
+
+Run: `pip install argcomplete && python -c "import argcomplete; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml pironman5/_cli.py
+git commit -m "feat(cli): add argcomplete bash auto-completion
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Commit installer script change
+
+**Repo:** `F:\workspace\sunfounder-installer-scripts`
+**Files:**
+- Modify: `pironman5/install.sh`
+
+- [ ] **Step 1: Verify the install.sh change is in place**
+
+Confirm the argcomplete registration line from Task 3 Step 3 is present in install.sh.
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd F:/workspace/sunfounder-installer-scripts
+git add pironman5/install.sh
+git commit -m "feat(pironman5): register argcomplete bash completion on install
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-05-27-cli-enhancements-design.md
+++ b/docs/superpowers/specs/2026-05-27-cli-enhancements-design.md
@@ -1,0 +1,131 @@
+# CLI Enhancements: Auto-completion + Update + Uninstall
+
+Date: 2026-05-27
+Branch: `ups-beta`
+Status: approved
+
+## Feature 1: Bash auto-completion via argcomplete
+
+### Design
+
+Use the `argcomplete` Python package to auto-generate bash completions from the existing argparse parser. No hand-written completion script needed.
+
+### Changes
+
+**`pironman5/__init__.py`:**
+- Add `# PYTHON_ARGCOMPLETE_OK` comment near the top of the file (convention for argcomplete to locate the script)
+- After `parser` is fully defined and before `parse_known_args()`, add `argcomplete.autocomplete(parser)`
+
+**`pyproject.toml`:**
+- Add `argcomplete` to `dependencies`
+
+**`sunfounder-installer-scripts/pironman5/install.sh`:**
+- After the pip install step and symlink creation, add:
+  ```bash
+  /opt/pironman5/venv/bin/register-python-argcomplete pironman5 > /etc/bash_completion.d/pironman5
+  ```
+  or via the symlink:
+  ```bash
+  register-python-argcomplete pironman5 > /etc/bash_completion.d/pironman5
+  ```
+
+### Behavior
+
+- Installed automatically, no user action needed
+- `pironman5 --<TAB>` completes all flags
+- `pironman5 <TAB>` completes subcommands: `start`, `stop`, `pipower5`, `update`, `uninstall`
+- Flag values with `choices` (e.g., `--debug-level`, `--rgb-style`) auto-complete
+
+---
+
+## Feature 2: `pironman5 update`
+
+### Design
+
+Re-run the same installer script used for initial installation. This ensures all components (pironman5, pm_auto, pm_dashboard, sf_rpi_status, system dependencies, DT overlays, systemd service) stay in sync with the installer's latest logic.
+
+### CLI
+
+```
+pironman5 update [--variant <name>] [--pipower5]
+```
+
+- `--variant`: optional, defaults to reading `/opt/pironman5/.variant`
+- `--pipower5`: optional, defaults to checking `/opt/pironman5/.custom_module`
+
+### Execution flow
+
+1. Read `/opt/pironman5/.variant` to detect current variant
+2. Check `/opt/pironman5/.custom_module` for `pipower5` support
+3. Build curl command targeting the installer on the `main` branch
+4. Execute: `curl -sSL "https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/main/pironman5/install.sh" | sudo bash -s -- --variant <variant> [--pipower5] [--plain-text]`
+5. The installer runs idempotently: stops service, updates code, restarts service
+
+### Changes
+
+- Add `update` subparser to `pironman5/__init__.py`
+- Add `--variant` and `--pipower5` flags to the `update` subparser
+- Implementation reads `.variant` and `.custom_module` files, constructs and runs the curl command
+
+---
+
+## Feature 3: `pironman5 uninstall`
+
+### Design
+
+Completely remove pironman5 from the system with interactive confirmation prompts.
+
+### CLI
+
+```
+pironman5 uninstall [--yes]
+```
+
+- `--yes`: skip all confirmation prompts (for scripting)
+
+### Execution flow
+
+1. **Confirmation:** "This will completely remove Pironman 5 and all its data. Continue? [y/N]"
+2. **Stop and disable service:**
+   - `systemctl stop pironman5.service`
+   - `systemctl disable pironman5.service`
+   - Remove `/etc/systemd/system/pironman5.service`
+   - `systemctl daemon-reload`
+3. **Remove symlinks:** `rm /usr/local/bin/pironman5`
+4. **Remove user/group:**
+   - `userdel pironman5` (or `deluser pironman5`)
+   - `groupdel pironman5` (or `delgroup pironman5`) if group exists
+5. **Remove directories:**
+   - `rm -rf /opt/pironman5/`
+   - `rm -rf /var/log/pironman5/`
+6. **InfluxDB prompt:** "Uninstall InfluxDB database too? [y/N]"
+   - If yes: `apt-get purge influxdb -y`
+7. **Done:** "Pironman 5 has been uninstalled."
+
+### What is NOT removed
+
+- **DT overlays** in `/boot/firmware/overlays/` — these will eventually be upstreamed to the kernel
+- **APT system dependencies** — cannot determine if other software depends on them
+- **pipower5** (separate package, user may keep it)
+
+### Changes
+
+- Add `uninstall` subparser to `pironman5/__init__.py`
+- Add `--yes` flag
+- Uninstall logic implemented as a standalone function (not dependent on `install.sh`)
+
+---
+
+## Files changed
+
+| Repo | File | Changes |
+|---|---|---|
+| pironman5 | `pironman5/__init__.py` | argcomplete setup + `update`/`uninstall` subcommands |
+| pironman5 | `pyproject.toml` | add `argcomplete` dependency |
+| sunfounder-installer-scripts | `pironman5/install.sh` | add argcomplete registration |
+
+## Dependencies
+
+- `argcomplete` Python package (pip)
+- `bash` with bash-completion installed (default on Raspbian)
+- `curl` and `sudo` (already required by installer)

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -662,8 +662,9 @@ def main():
     # ----------------------------------------
     if args.subcommand == 'uninstall':
         if os.geteuid() != 0:
-            print("Error: uninstall requires root privileges. Run with: sudo pironman5 uninstall")
-            sys.exit(1)
+            print("Requesting root privileges...")
+            os.execvp('sudo', ['sudo', 'pironman5'] + sys.argv[1:])
+            sys.exit(0)
 
         def _confirm(prompt):
             if args.yes:

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -109,6 +109,9 @@ def main():
     stop_parser = subparsers.add_parser("stop", help="Stop Pironman5")
     launch_browser_parser = subparsers.add_parser("launch-browser", help="Launch browser")
     launch_browser_parser.add_argument("-a", "--auto-start", nargs='?', default='', help="Auto start browser on boot")
+    update_parser = subparsers.add_parser("update", help="Update Pironman5 to latest version")
+    update_parser.add_argument("--variant", nargs='?', default='', help="Override variant (base/mini/max/pro-max/ups/nas)")
+    update_parser.add_argument("--pipower5", action="store_true", help="Include PiPower5 support")
 
     # parse args
     # -----------------------------------------------------------
@@ -606,6 +609,48 @@ def main():
             except FileNotFoundError:
                 print("Error: pipower5 command not found, please make sure it is installed and in the environment variables", file=sys.stderr)
                 sys.exit(1)
+
+    # update
+    # ----------------------------------------
+    if args.subcommand == 'update':
+        variant = args.variant if args.variant else ''
+        if not variant:
+            try:
+                with open('/opt/pironman5/.variant', 'r') as f:
+                    variant = f.read().strip()
+            except FileNotFoundError:
+                print("Error: Cannot detect variant. /opt/pironman5/.variant not found.")
+                print("Specify variant manually: pironman5 update --variant base")
+                sys.exit(1)
+
+        if not variant:
+            print("Error: Empty variant. Specify manually: pironman5 update --variant base")
+            sys.exit(1)
+
+        use_pipower5 = args.pipower5
+        if not use_pipower5:
+            try:
+                with open('/opt/pironman5/.custom_module', 'r') as f:
+                    if 'pipower5' in f.read():
+                        use_pipower5 = True
+            except FileNotFoundError:
+                pass
+
+        installer_url = "https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/main/pironman5/install.sh"
+        cmd_parts = ["curl -sSL", installer_url, "| sudo bash -s -- --variant", variant, "--plain-text"]
+        if use_pipower5:
+            cmd_parts.append("--pipower5")
+
+        cmd = ' '.join(cmd_parts)
+        print(f"Updating Pironman 5 ({variant})...")
+        print(f"Running: {cmd}")
+        ret = os.system(cmd)
+        if ret != 0:
+            print(f"Update failed with exit code {ret}", file=sys.stderr)
+            sys.exit(1)
+        print("Update complete. Restarting service...")
+        os.system('systemctl restart pironman5.service')
+        quit()
 
     # Update settings
     # ----------------------------------------

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -704,8 +704,8 @@ def main():
         if sudo_user:
             os.system(f'rm -rf /home/{sudo_user}/pironman5')
 
-        if _confirm("Uninstall InfluxDB database too?"):
-            os.system('apt-get purge influxdb -y')
+        if _confirm("Remove InfluxDB data (pironman5 database)?"):
+            os.system('influx -execute "DROP DATABASE pironman5" 2>/dev/null')
 
         print("Pironman 5 has been uninstalled.")
         quit()

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -700,6 +700,9 @@ def main():
         print("Removing directories...")
         os.system('rm -rf /opt/pironman5/')
         os.system('rm -rf /var/log/pironman5/')
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user:
+            os.system(f'rm -rf /home/{sudo_user}/pironman5')
 
         if _confirm("Uninstall InfluxDB database too?"):
             os.system('apt-get purge influxdb -y')

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -643,7 +643,7 @@ def main():
                 pass
 
         installer_url = "https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/main/pironman5/install.sh"
-        cmd_parts = ["curl -sSL", installer_url, "| sudo bash -s -- --variant", variant, "--plain-text"]
+        cmd_parts = ["curl -sSL", installer_url, "| sudo bash -s -- --variant", variant]
         if use_pipower5:
             cmd_parts.append("--pipower5")
 

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -1,8 +1,10 @@
+# PYTHON_ARGCOMPLETE_OK
 
 import argparse
 import json
 import sys
 import os
+import argcomplete
 from importlib.resources import files as resource_files
 
 from ._launch_browser import run as launch_browser
@@ -114,6 +116,8 @@ def main():
     update_parser.add_argument("--pipower5", action="store_true", help="Include PiPower5 support")
     uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall Pironman5 completely")
     uninstall_parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts")
+
+    argcomplete.autocomplete(parser)
 
     # parse args
     # -----------------------------------------------------------

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -643,7 +643,7 @@ def main():
                 pass
 
         installer_url = "https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/main/pironman5/install.sh"
-        cmd_parts = ["curl -sSL", installer_url, "| sudo bash -s -- --variant", variant]
+        cmd_parts = ["echo n | curl -sSL", installer_url, "| sudo bash -s -- --variant", variant]
         if use_pipower5:
             cmd_parts.append("--pipower5")
 
@@ -655,7 +655,7 @@ def main():
             print(f"Update failed with exit code {ret}", file=sys.stderr)
             sys.exit(1)
         print("Update complete. Restarting service...")
-        os.system('systemctl restart pironman5.service')
+        os.system('sudo systemctl restart pironman5.service')
         quit()
 
     # uninstall

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -661,6 +661,10 @@ def main():
     # uninstall
     # ----------------------------------------
     if args.subcommand == 'uninstall':
+        if os.geteuid() != 0:
+            print("Error: uninstall requires root privileges. Run with: sudo pironman5 uninstall")
+            sys.exit(1)
+
         def _confirm(prompt):
             if args.yes:
                 return True
@@ -676,8 +680,8 @@ def main():
             quit()
 
         print("Stopping service...")
-        os.system('systemctl stop pironman5.service 2>/dev/null')
-        os.system('systemctl disable pironman5.service 2>/dev/null')
+        os.system('systemctl stop pironman5.service')
+        os.system('systemctl disable pironman5.service')
         service_file = '/etc/systemd/system/pironman5.service'
         if os.path.exists(service_file):
             os.remove(service_file)

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -112,6 +112,8 @@ def main():
     update_parser = subparsers.add_parser("update", help="Update Pironman5 to latest version")
     update_parser.add_argument("--variant", nargs='?', default='', help="Override variant (base/mini/max/pro-max/ups/nas)")
     update_parser.add_argument("--pipower5", action="store_true", help="Include PiPower5 support")
+    uninstall_parser = subparsers.add_parser("uninstall", help="Uninstall Pironman5 completely")
+    uninstall_parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts")
 
     # parse args
     # -----------------------------------------------------------
@@ -650,6 +652,50 @@ def main():
             sys.exit(1)
         print("Update complete. Restarting service...")
         os.system('systemctl restart pironman5.service')
+        quit()
+
+    # uninstall
+    # ----------------------------------------
+    if args.subcommand == 'uninstall':
+        def _confirm(prompt):
+            if args.yes:
+                return True
+            while True:
+                resp = input(prompt + " [y/N] ")
+                if resp.lower() in ('y', 'yes'):
+                    return True
+                elif resp.lower() in ('', 'n', 'no'):
+                    return False
+
+        if not _confirm("This will completely remove Pironman 5 and all its data. Continue?"):
+            print("Uninstall cancelled.")
+            quit()
+
+        print("Stopping service...")
+        os.system('systemctl stop pironman5.service 2>/dev/null')
+        os.system('systemctl disable pironman5.service 2>/dev/null')
+        service_file = '/etc/systemd/system/pironman5.service'
+        if os.path.exists(service_file):
+            os.remove(service_file)
+            os.system('systemctl daemon-reload')
+
+        print("Removing symlinks...")
+        symlink_path = '/usr/local/bin/pironman5'
+        if os.path.exists(symlink_path):
+            os.remove(symlink_path)
+
+        print("Removing user and group...")
+        os.system('userdel pironman5 2>/dev/null')
+        os.system('groupdel pironman5 2>/dev/null')
+
+        print("Removing directories...")
+        os.system('rm -rf /opt/pironman5/')
+        os.system('rm -rf /var/log/pironman5/')
+
+        if _confirm("Uninstall InfluxDB database too?"):
+            os.system('apt-get purge influxdb -y')
+
+        print("Pironman 5 has been uninstalled.")
         quit()
 
     # Update settings

--- a/pironman5/pironman5.py
+++ b/pironman5/pironman5.py
@@ -170,7 +170,7 @@ class Pironman5:
         if len(patch) > 0:
             self.log.debug(f"Update config: {patch}")
             self.config['system'].update(patch)
-            self.log.debug(f"New config: {json.dumps(self.config, indent=4)}")
+            self.log.debug(f"Config updated: {list(patch.keys())}")
             with open(self.config_path, 'w') as f:
                 json.dump(self.config, f, indent=4)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 
-dependencies = []
+dependencies = [
+    "argcomplete",
+]
 
 [project.scripts]
 pironman5 = "pironman5:_cli.main"


### PR DESCRIPTION
## Summary

- Add `pironman5 update` subcommand — re-runs the canonical install.sh to update all components
- Add `pironman5 uninstall` subcommand — completely removes Pironman 5 with confirmation prompts (auto-elevates to root via sudo)
- Add bash auto-completion via argcomplete — zero-config, auto-generated from argparse
- Add argcomplete registration to install.sh for new installations

## How to test

On a Pironman 5 device:

```bash
# Auto-completion
pironman5 <TAB>           # lists: start, stop, update, uninstall, pipower5, launch-browser

# Update
pironman5 update          # runs install.sh with auto-detected variant

# Uninstall
pironman5 uninstall       # prompts for confirmation, removes everything
pironman5 uninstall -y     # skip confirmation prompts
```

## Changes

| File | Change |
|---|---|
| `pironman5/_cli.py` | Add update/uninstall subcommands, argcomplete setup |
| `pyproject.toml` | Add argcomplete dependency |
| `docs/superpowers/specs/` | Design spec |
| `docs/superpowers/plans/` | Implementation plan |

## Note

Installer companion change at `sunfounder-installer-scripts` adds argcomplete Bash completion registration on new installations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)