### PR TITLE
fix(scripts): use -g pipower5 when creating user to avoid group conflict

### DIFF
--- a/scripts/setup_pipower5.sh
+++ b/scripts/setup_pipower5.sh
@@ -91,7 +91,7 @@ rm -rf email_templates.zip email_templates/
 
 # create pipower5 user
 if ! id -u pipower5 > /dev/null 2>&1; then
-    useradd -m pipower5
+    useradd -m -g pipower5 pipower5
 fi
 #create udev rules
 if [ ! -d /etc/udev/rules.d ]; then


### PR DESCRIPTION
## Problem

When installing with `--pipower5`, `setup_pipower5.sh` fails:

```
useradd: group pipower5 exists - if you want to add this user to that group, use -g.
Error occurred. Exiting...
```

## Root Cause

The pironman5 installer framework creates the `pipower5` group before `setup_pipower5.sh` runs. When the script later calls `useradd -m pipower5`, it tries to create a group with the same name, which fails.

## Fix

Change `useradd -m pipower5` to `useradd -m -g pipower5 pipower5` to explicitly assign the existing group.