### PR TITLE
fix(launch-browser): warn instead of error when XDG_SESSION_TYPE is empty

### DIFF
--- a/pironman5/_launch_browser.py
+++ b/pironman5/_launch_browser.py
@@ -28,7 +28,9 @@ def check_desktop_environment() -> bool:
     
     # Core check 2: Session type (distinguish desktop/console)
     session_type = os.getenv("XDG_SESSION_TYPE", "")
-    if session_type not in ["x11", "wayland"]:
+    if not session_type:
+        print("Warning: XDG_SESSION_TYPE not set. DISPLAY is present, attempting launch anyway.", file=sys.stderr)
+    elif session_type not in ["x11", "wayland"]:
         print(f"Error: Current session type is {session_type}. Only x11/wayland desktop sessions are supported.", file=sys.stderr)
         return False
     


### PR DESCRIPTION
## Problem

During Pro Max installation, the auto-launch browser step fails with:

```
Error: Current session type is . Only x11/wayland desktop sessions are supported.
```

This happens when `$DISPLAY` is set but `$XDG_SESSION_TYPE` is unset (common in SSH with X forwarding, minimal desktop environments, or certain display managers).

## Fix

When `XDG_SESSION_TYPE` is empty but `DISPLAY` is present, warn instead of erroring out. Still error if `XDG_SESSION_TYPE` is explicitly set to a non-desktop value like "tty".