### PR TITLE
fix(promax): remove pwm_fan module - Pro Max has no fan speed sensor

### DIFF
--- a/pironman5/variants/products.py
+++ b/pironman5/variants/products.py
@@ -72,7 +72,7 @@ PRODUCT_DEFINITIONS = {
         "product_version": "",
         "modules": [
             "core", "network_info", "history", "oled", "ws2812",
-            "pwm_fan", "gpio_fan",
+            "gpio_fan",
             "pi5_power_button",
         ],
         "config_overrides": {


### PR DESCRIPTION
## Problem

Pro Max temperature card shows CPU Fan Speed, but Pro Max GPIO fans don't report RPM speed.

## Fix

Remove `pwm_fan` module from Pro Max product definition. This drops the `pwm_fan_speed` peripheral, which hides CPU Fan Speed from the dashboard temperature card.

Fan control via `gpio_fan` (`gpio_fan_state` / `gpio_fan_mode`) is unaffected.