### PR TITLE
fix(ci): prevent Docker build failures from missing /root and empty HOME

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,9 +22,6 @@ jobs:
           - variant: base
             pipower5: "false"
             suffix: ""
-          - variant: mini
-            pipower5: "false"
-            suffix: ""
           - variant: max
             pipower5: "false"
             suffix: ""
@@ -44,6 +41,33 @@ jobs:
           repository: sunfounder/sunfounder-installer-scripts
           ref: main
           path: installer-scripts
+
+      - name: Patch installer-scripts for CI fix
+        shell: python
+        run: |
+          import shutil
+
+          # 1. Copy newer install.sh from pironman5 repo (fixes CD+HOME+CLONE fragile chain)
+          shutil.copy('pironman5/install.sh', 'installer-scripts/pironman5/install.sh')
+          print("✓ install.sh replaced with pironman5 repo version")
+
+          # 2. Patch Dockerfile — add ENV USER=root so framework getent resolves correctly
+          with open('installer-scripts/pironman5/Dockerfile', 'r') as f:
+              content = f.read()
+          content = content.replace('ENV HOME=/root', 'ENV USER=root\nENV HOME=/root')
+          with open('installer-scripts/pironman5/Dockerfile', 'w') as f:
+              f.write(content)
+          print("✓ Dockerfile patched: ENV USER=root added")
+
+          # 3. Patch framework — fallback to $HOME if getent returns empty
+          with open('installer-scripts/tools/installer_1.1.0.sh', 'r') as f:
+              content = f.read()
+          old = 'HOME=$(getent passwd $USERNAME | cut -d: -f6)'
+          new = 'NEW_HOME=$(getent passwd $USERNAME | cut -d: -f6)\nHOME=${NEW_HOME:-$HOME}'
+          content = content.replace(old, new)
+          with open('installer-scripts/tools/installer_1.1.0.sh', 'w') as f:
+              f.write(content)
+          print("✓ installer_1.1.0.sh patched: HOME fallback added")
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
## 问题

CI Docker 构建在 1.3.x 分支失败，错误链：

\`\`\`
cd: /root: No such file or directory
→ git clone 在错误目录执行
→ 后续所有命令找不到文件（scripts/install_influxdb.sh、pyproject.toml）
\`\`\`

## 根因

三个层面同时出问题：

1. **installer-scripts 的 install.sh (v1.0.1)** 用了脆弱的 CD+HOME+CLONE（不指定目标路径）组合
2. **框架 installer_1.1.0.sh** 用 getent passwd 覆盖 HOME，Docker 中 USER 未设置时返回空
3. **Dockerfile** 只设了 ENV HOME=/root 但没设 ENV USER=root

## 修复（纵深防御）

新增 Patch installer-scripts for CI fix 步骤，构建前自动修复三个文件：

| 层级 | 修复 |
|------|------|
| install.sh | CD+HOME+CLONE → RUN git clone 显式目标路径 |
| Dockerfile | 新增 ENV USER=root |
| 框架 | HOME fallback: \${NEW_HOME:-\$HOME} |

同时从 CI matrix 移除了已关闭的 mini variant。