### PR TITLE
docs: fix install link to 1.3.x, remove redundant auto-launch section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Quick Links:
 curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash
 ```
 
+To install PiPower5 as a plugin alongside Pironman 5, append `--pipower5`:
+
+```bash
+curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash -s -- --pipower5
+```
+
 ### Pro Max
 
 > **💡 Touchscreen mode:** We recommend changing the touchscreen mode to **Multitouch** instead of Mouse Emulation.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ To install PiPower5 as a plugin alongside Pironman 5, append `--pipower5`:
 curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash -s -- --pipower5
 ```
 
-### Pro Max
-
-> **💡 Touchscreen mode:** We recommend changing the touchscreen mode to **Multitouch** instead of Mouse Emulation.
+> **For Pro Max:** The Pro Max includes a 4.3" touchscreen and can auto-launch the dashboard on boot. We recommend switching the touchscreen mode from the default **Mouse Emulation** to **Multitouch** — this enables phone/tablet-like touch gestures and makes the dashboard much easier to use.
 >
 > 1. **Raspberry Pi Icon** >> **Preferences** >> **Control Centre**
 > 2. Select **Screen** tab

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Quick Links:
   - [About Pironman5](#about-pironman5)
   - [Links](#links)
   - [Installation](#installation)
-  - [Auto launch dashboard on browser](#auto-launch-dashboard-on-browser)
   - [Update](#update)
   - [Compatible Systems](#compatible-systems)
     - [Ubuntu 24.04 server eth0 and wifi not work](#ubuntu-2404-server-eth0-and-wifi-not-work)
@@ -26,21 +25,17 @@ Quick Links:
 ## Installation
 
 ```bash
-curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/promax/install.sh" | sudo bash
+curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash
 ```
 
-## Auto launch dashboard on browser
+### Pro Max
 
-```bash
-pironman5 launch-browser --auto-start=on
-```
-
-You also want to change touchscreen mode to Multitouch instead of Mouse Emulation.
-
-1. **Raspberry Pi Icon** >> **Preferences** >> **Control Centre**.
-2. Select **Screen** tab.
-3. Long press/right click on **DSI-2**, 
-4. Select **Touchscreen** >> **Mode** >> **Multitouch**.
+> **💡 Touchscreen mode:** We recommend changing the touchscreen mode to **Multitouch** instead of Mouse Emulation.
+>
+> 1. **Raspberry Pi Icon** >> **Preferences** >> **Control Centre**
+> 2. Select **Screen** tab
+> 3. Long press / right click on **DSI-2**
+> 4. Select **Touchscreen** >> **Mode** >> **Multitouch**
 
 ## Update
 


### PR DESCRIPTION
## 改动

1. **安装链接修复** — \`promax\` 分支 → \`1.3.x\` 分支
2. **移除冗余的 Auto launch 章节** — \`pironman5 launch-browser --auto-start=on\` 已内置在安装脚本中，README 不需要重复
3. **触摸屏提示改为 Pro Max 专属引用格式** — 保留但用 \`### Pro Max\` 标题 + blockquote 标明这是 Pro Max 的小提醒