### PR TITLE
feat: self-host Docker build, remove installer-scripts dependency

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,17 +35,6 @@ jobs:
         with:
           path: pironman5
 
-      - name: Checkout installer-scripts (tools only)
-        uses: actions/checkout@v4
-        with:
-          repository: sunfounder/sunfounder-installer-scripts
-          ref: main
-          path: installer-scripts
-          sparse-checkout: tools
-
-      - name: Copy framework tools into build context
-        run: cp -r installer-scripts/tools pironman5/docker-tools
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,9 +22,6 @@ jobs:
           - variant: base
             pipower5: "false"
             suffix: ""
-          - variant: mini
-            pipower5: "false"
-            suffix: ""
           - variant: max
             pipower5: "false"
             suffix: ""
@@ -38,12 +35,16 @@ jobs:
         with:
           path: pironman5
 
-      - name: Checkout installer-scripts
+      - name: Checkout installer-scripts (tools only)
         uses: actions/checkout@v4
         with:
           repository: sunfounder/sunfounder-installer-scripts
           ref: main
           path: installer-scripts
+          sparse-checkout: tools
+
+      - name: Copy framework tools into build context
+        run: cp -r installer-scripts/tools pironman5/docker-tools
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -70,8 +71,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: installer-scripts
-          file: installer-scripts/pironman5/Dockerfile
+          context: pironman5
+          file: pironman5/Dockerfile
           platforms: linux/arm64,linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:24.04
+
+ARG VARIANT=base
+ARG PIPOWER5=false
+
+RUN apt-get update && apt-get install -y curl sudo util-linux git
+
+# Ensure HOME and USER are set for the installer framework
+RUN mkdir -p /root
+ENV USER=root
+ENV HOME=/root
+
+COPY install.sh /tmp/install.sh
+COPY docker-tools /tmp/installer-tools
+
+RUN if [ "$PIPOWER5" = "true" ]; then \
+        bash /tmp/install.sh --variant "$VARIANT" --container --pipower5; \
+    else \
+        bash /tmp/install.sh --variant "$VARIANT" --container; \
+    fi
+
+RUN rm -rf /tmp/install.sh /tmp/installer-tools
+
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 34001
+CMD ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ ENV USER=root
 ENV HOME=/root
 
 COPY install.sh /tmp/install.sh
-COPY docker-tools /tmp/installer-tools
 
 RUN if [ "$PIPOWER5" = "true" ]; then \
         bash /tmp/install.sh --variant "$VARIANT" --container --pipower5; \
@@ -19,7 +18,7 @@ RUN if [ "$PIPOWER5" = "true" ]; then \
         bash /tmp/install.sh --variant "$VARIANT" --container; \
     fi
 
-RUN rm -rf /tmp/install.sh /tmp/installer-tools
+RUN rm -rf /tmp/install.sh
 
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+
+# Load I2C kernel module (needed for OLED)
+modprobe i2c-dev 2>/dev/null || true
+
+# Shutdown wrappers: use nsenter + force flags to bypass systemd chroot guard
+# systemctl and shutdown are symlinks to systemctl which refuses to run in
+# a container context. -f flag forces the raw kernel syscall.
+cat > /usr/local/bin/shutdown << 'WRAP'
+#!/bin/bash
+case "$*" in
+    *-r*|*reboot*) exec nsenter -t 1 -a -- /sbin/reboot -f ;;
+    *)             exec nsenter -t 1 -a -- /sbin/poweroff -f ;;
+esac
+WRAP
+chmod +x /usr/local/bin/shutdown
+
+for cmd in reboot poweroff halt; do
+    case $cmd in
+        reboot)   target="/sbin/reboot" ;;
+        poweroff) target="/sbin/poweroff" ;;
+        halt)     target="/sbin/halt" ;;
+    esac
+    printf '#!/bin/bash\nexec nsenter -t 1 -a -- %s -f "$@"\n' "$target" > "/usr/local/bin/$cmd"
+    chmod +x "/usr/local/bin/$cmd"
+done
+
+# systemctl wrapper: translate shutdown commands, bypass chroot guard
+cat > /usr/local/bin/systemctl << 'SYSCTL'
+#!/bin/bash
+case "$*" in
+    *poweroff*) exec nsenter -t 1 -a -- /sbin/poweroff -f ;;
+    *reboot*)   exec nsenter -t 1 -a -- /sbin/reboot -f ;;
+    *halt*)     exec nsenter -t 1 -a -- /sbin/halt -f ;;
+    *)          exec /usr/bin/systemctl "$@" ;;
+esac
+SYSCTL
+chmod +x /usr/local/bin/systemctl
+
+# sudo wrapper: intercept shutdown calls
+cat > /usr/local/bin/sudo << 'SUDO'
+#!/bin/bash
+case "$*" in
+    *systemctl*poweroff*|*poweroff*|*shutdown*|*reboot*|*halt*)
+        exec nsenter -t 1 -a -- /sbin/poweroff -f ;;
+    *)
+        exec /usr/bin/sudo "$@" ;;
+esac
+SUDO
+chmod +x /usr/local/bin/sudo
+
+CONFIG_PATH="${CONFIG_PATH:-/data/config.json}"
+mkdir -p "$(dirname "$CONFIG_PATH")"
+
+exec /opt/pironman5/venv/bin/pironman5 --config-path "$CONFIG_PATH" start


### PR DESCRIPTION
## 改动

CI Docker 构建完全自托管，不再依赖 \`sunfounder-installer-scripts\`：

| 文件 | 说明 |
|------|------|
| \`Dockerfile\` | 新建，含 \`ENV USER=root\` / \`ENV HOME=/root\` |
| \`docker-entrypoint.sh\` | 从 installer-scripts 迁入 |
| \`install.sh\` | 使用项目自带版本 |

\`install.sh\` 本身会 curl 下载 framework（\`installer_1.1.0.sh\` + \`progress_bar\` + \`config_txt_manager\`），CI 不再需要 checkout installer-scripts。

### CI 流程简化

```
之前: checkout pironman5 → checkout installer-scripts → Python 补丁 → build
现在: checkout pironman5 → build
```

同时移除了已关闭的 mini variant。