### PR TITLE
docs: add download-then-run alternative for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ To install PiPower5 as a plugin alongside Pironman 5, append `--pipower5`:
 curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash -s -- --pipower5
 ```
 
+> If your system does not support piping directly into `bash`, download the script first and then run it:
+>
+> ```bash
+> curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" -o install.sh
+> sudo bash install.sh
+> ```
+>
+> With PiPower5 plugin:
+>
+> ```bash
+> curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" -o install.sh
+> sudo bash install.sh --pipower5
+> ```
+
 > **For Pro Max:** The Pro Max includes a 4.3" touchscreen and can auto-launch the dashboard on boot. We recommend switching the touchscreen mode from the default **Mouse Emulation** to **Multitouch** — this enables phone/tablet-like touch gestures and makes the dashboard much easier to use.
 >
 > 1. **Raspberry Pi Icon** >> **Preferences** >> **Control Centre**


### PR DESCRIPTION
﻿Some systems may not support piping directly into `bash` (e.g. `curl ... | sudo bash`). This adds a "download first, then run" alternative in the Installation section, for both the standard install and the PiPower5 plugin variant.
