### PR TITLE
feat: Pro Max auto-installs pi-hdmi-edid for HDMI audio splitter

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -577,6 +577,11 @@ if [ "$INSTALL_PIPOWER5" = true ]; then
     RUN "echo -n 'pipower5' > /opt/pironman5/.custom_module" "Write custom module"
 fi
 
+if [ "$IS_CONTAINER" = false ] && [ "$variant" = "pro_max" ]; then
+    _hdmi_url="${GIT_REPO}pi-hdmi-edid/raw/main/install.sh"
+    RUN "curl -fsSL \"$_hdmi_url\" | bash" "Install HDMI EDID plugin"
+fi
+
 # --- Write dtoverlay to config.txt ---
 if [ "$IS_CONTAINER" = false ]; then
     TITLE "Configure device tree overlays"


### PR DESCRIPTION
## Description

Pro Max 安装完成后自动运行 pi-hdmi-edid 安装脚本，设置虚拟 EDID 使 HDMI 音频分离器可用。

## Changes

install.sh +5 lines.

## Note

- URL derived from GIT_REPO (framework auto-detects GitHub/Gitee)
- Temporary solution -- revert this commit to remove
