### PR TITLE
fix(install): ensure kernel headers persist + load pipower5 module

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -328,8 +328,8 @@ if [ "$_PLUGIN_ONLY" = true ]; then
 
         TITLE "Build and install kernel driver"
         RUN "apt-get install -y dkms 2>&1 || { printf 'Types: deb\nURIs: http://deb.debian.org/debian/\nSuites: trixie trixie-updates\nComponents: main contrib non-free non-free-firmware\nSigned-By: /usr/share/keyrings/debian-archive-keyring.pgp\n' > /etc/apt/sources.list.d/debian-trixie.sources && apt-get update && apt-get install -y dkms 2>&1; }" "Install DKMS"
-        RUN "apt-get install -y linux-headers-\$(uname -r)" "Install kernel headers"
-        RUN "cd ${PIPOWER5_SRC}/driver && make clean && make module && make dkms_install && make dtbo" "Build and install pipower5.ko"
+        RUN "apt-get install -y linux-headers-raspi linux-headers-\$(uname -r)" "Install kernel headers"
+        RUN "cd ${PIPOWER5_SRC}/driver && make clean && make module && make dkms_install && make dtbo && modprobe pipower5 || true" "Build and install pipower5.ko"
 
         if [ -f "${VENV_PIP}" ]; then
             TITLE "Install PiPower5 Python package"
@@ -485,10 +485,10 @@ if [ "$INSTALL_PIPOWER5" = true ]; then
 
     TITLE "Install PiPower5 build dependencies"
     RUN "apt-get install -y dkms 2>&1 || { printf 'Types: deb\nURIs: http://deb.debian.org/debian/\nSuites: trixie trixie-updates\nComponents: main contrib non-free non-free-firmware\nSigned-By: /usr/share/keyrings/debian-archive-keyring.pgp\n' > /etc/apt/sources.list.d/debian-trixie.sources && apt-get update && apt-get install -y dkms 2>&1; }" "Install DKMS"
-    RUN "apt-get install -y linux-headers-\$(uname -r)" "Install kernel headers"
+    RUN "apt-get install -y linux-headers-raspi linux-headers-\$(uname -r)" "Install kernel headers"
 
     TITLE "Build and install PiPower5 kernel driver"
-    RUN "cd ${PIPOWER5_SRC}/driver && make clean && make module && make dkms_install && make dtbo && make install-overlay" "Build and install pipower5.ko"
+    RUN "cd ${PIPOWER5_SRC}/driver && make clean && make module && make dkms_install && make dtbo && make install-overlay && modprobe pipower5 || true" "Build and install pipower5.ko"
 
     TITLE "Install PiPower5 Python package"
     RUN "${VENV_PIP} install git+${GIT_REPO}pipower5.git@${PIPOWER5_BRANCH}" "Install pipower5"


### PR DESCRIPTION
## Problem

On Ubuntu, installing pironman5 with PiPower5 requires a second installation before the driver works correctly. Two root causes:

**1. Kernel headers not installed for future updates**

Ubuntu's `linux-image-raspi` meta-package does NOT depend on `linux-headers-raspi`. When the kernel updates via apt, headers are not pulled in. DKMS then cannot auto-rebuild the pipower5 module, and the driver breaks after reboot.

Evidence from Ubuntu 26.04:
```
$ apt-cache depends linux-image-raspi
  Depends: linux-image-7.0.0-1011-raspi
  Depends: linux-firmware
  (no linux-headers-raspi!)
```

**2. Module not loaded after install**

The install script calls `make dkms_install` which builds and registers the module with DKMS, but never loads it with modprobe. The module sits on disk until next reboot.

## Fix

Two changes in install.sh (applied in both plugin-only path and main variant path):

1. Add `linux-headers-raspi` to the kernel headers install line, ensuring the meta-package is installed so future kernel updates automatically pull in headers.

2. Add `modprobe pipower5 || true` after `make dkms_install`, loading the module immediately after installation.

## Testing

Verified on Ubuntu 26.04 (aarch64) on Raspberry Pi 5:
- Installing `linux-headers-raspi` triggered DKMS auto-rebuild for kernel 7.0.0-1011-raspi
- `modprobe pipower5` loaded the module successfully
- `pipower5 doctor` confirmed all checks passing