### PR TITLE
Fix InfluxDB data directory permission issue after install (#88)

### DIFF
--- a/scripts/install_influxdb.sh
+++ b/scripts/install_influxdb.sh
@@ -21,6 +21,11 @@ echo 'deb [signed-by=/etc/apt/keyrings/influxdata-archive.gpg] https://repos.inf
 DEBIAN_FRONTEND=noninteractive apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get install -y influxdb
 
+if [ -d /var/lib/influxdb ]; then
+    chown -R influxdb:influxdb /var/lib/influxdb
+    find /var/lib/influxdb -type d -exec chmod 755 {} ;
+    find /var/lib/influxdb -type f -exec chmod 644 {} ;
+fi
 
 INFLUXDB_CONFIG="/etc/influxdb/influxdb.conf"
 # Disable InfluxDB logging to avoid cluttering the logs


### PR DESCRIPTION
## Description
Fixes #88

## Problem
On Ubuntu 24.04 fresh installs, pironman5 service can be active, but data logging fails due to InfluxDB shard file permission denied errors under /var/lib/influxdb/data.

## Cause
InfluxDB data directory ownership and modes are not normalized during installation in this flow, which can leave runtime write permissions inconsistent.

## Changes
* Add post-install permission normalization for /var/lib/influxdb
* Set ownership to influxdb:influxdb when the directory exists
* Normalize directory permissions to 755
* Normalize file permissions to 644

## Why this is safe
* Runs only when /var/lib/influxdb exists
* Uses standard InfluxDB ownership and conservative filesystem modes
* Does not change service startup logic or unrelated installer behavior

## Testing
Verified on Ubuntu 24.04.4 LTS:
* pironman5 service reaches active running state
* Repeated InfluxDB permission denied shard errors no longer appear
* Data logger starts normally after service restart