### PR TITLE
fix: detect OS before installing linux-headers-raspi (Debian compat)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -338,7 +338,7 @@ if [ "$_PLUGIN_ONLY" = true ]; then
 
         TITLE "Build and install kernel driver"
         RUN "apt-get install -y dkms 2>&1 || { printf 'Types: deb\nURIs: http://deb.debian.org/debian/\nSuites: trixie trixie-updates\nComponents: main contrib non-free non-free-firmware\nSigned-By: /usr/share/keyrings/debian-archive-keyring.pgp\n' > /etc/apt/sources.list.d/debian-trixie.sources && apt-get update && apt-get install -y dkms 2>&1; }" "Install DKMS"
-        RUN "apt-get install -y linux-headers-raspi linux-headers-\$(uname -r)" "Install kernel headers"
+        RUN "if grep -q 'ID=ubuntu' /etc/os-release 2>/dev/null; then apt-get install -y linux-headers-raspi linux-headers-\$(uname -r); else apt-get install -y linux-headers-\$(uname -r); fi" "Install kernel headers"
         RUN "cd ${PIPOWER5_SRC}/driver && make clean && make module && make dkms_install && make dtbo && modprobe pipower5 || true" "Build and install pipower5.ko"
 
         if [ -f "${VENV_PIP}" ]; then
@@ -504,7 +504,7 @@ if [ "$INSTALL_PIPOWER5" = true ]; then
 
     TITLE "Install PiPower5 build dependencies"
     RUN "apt-get install -y dkms 2>&1 || { printf 'Types: deb\nURIs: http://deb.debian.org/debian/\nSuites: trixie trixie-updates\nComponents: main contrib non-free non-free-firmware\nSigned-By: /usr/share/keyrings/debian-archive-keyring.pgp\n' > /etc/apt/sources.list.d/debian-trixie.sources && apt-get update && apt-get install -y dkms 2>&1; }" "Install DKMS"
-    RUN "apt-get install -y linux-headers-raspi linux-headers-\$(uname -r)" "Install kernel headers"
+    RUN "if grep -q 'ID=ubuntu' /etc/os-release 2>/dev/null; then apt-get install -y linux-headers-raspi linux-headers-\$(uname -r); else apt-get install -y linux-headers-\$(uname -r); fi" "Install kernel headers"
 
     TITLE "Build and install PiPower5 kernel driver"
     RUN "cd ${PIPOWER5_SRC}/driver && make clean && make module && make dkms_install && make dtbo && make install-overlay && modprobe pipower5 || true" "Build and install pipower5.ko"


### PR DESCRIPTION
## Problem

On Debian 13 (trixie) with Raspberry Pi OS kernel, the install script fails with:

```
E: Unable to locate package linux-headers-raspi
```

`linux-headers-raspi` is an **Ubuntu-specific** meta-package. On Debian with the rpi kernel, this package name doesn't exist.

## Fix (方案 B — OS detection)

Check `/etc/os-release` before installing. Ubuntu gets `linux-headers-raspi` as before; Debian skips it:

```bash
if grep -q 'ID=ubuntu' /etc/os-release; then
    apt-get install -y linux-headers-raspi linux-headers-$(uname -r)
else
    apt-get install -y linux-headers-$(uname -r)
fi
```

Applied to both locations (L341, L507).

## Verification

- **Debian 13**, Pi 5, 6.18.34+rpt-rpi-2712: skips `linux-headers-raspi`, installs headers ✓
- **Ubuntu**: behavior unchanged — `linux-headers-raspi` still included ✓