### PR TITLE
cli: fix -c to show effective config instead of raw file content

### DIFF
--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -11,7 +11,7 @@ from ._launch_browser import run as launch_browser
 from .variants import NAME, PERIPHERALS
 from .pironman5 import Pironman5
 from .version import __version__
-from .utils import is_included, constrain
+from .utils import is_included, constrain, build_effective_config
 
 AVAILABLE_PAGES = []
 AVAILABLE_EMAIL_MODES = []
@@ -171,7 +171,8 @@ def main():
                 content = f.read()
                 if content == '':
                     current_config = {'system': {}}
-                current_config = json.loads(content)
+                else:
+                    current_config = json.loads(content)
             except json.JSONDecodeError:
                 print(f"Invalid config file: {config_path}")
                 quit()
@@ -179,7 +180,8 @@ def main():
     # show config
     # ----------------------------------------
     if args.config:
-        print(json.dumps(current_config, indent=4))
+        effective_config = build_effective_config(current_config)
+        print(json.dumps(effective_config, indent=4))
         quit()
 
     # get or set debug level

--- a/pironman5/pironman5.py
+++ b/pironman5/pironman5.py
@@ -28,9 +28,9 @@ def _format_json(obj, max_level=2, indent=2, _level=0):
 from pm_auto.pm_auto import PMAuto
 from pm_auto import __version__ as pm_auto_version
 from .logger import Logger
-from .utils import merge_dict, log_error
+from .utils import log_error, build_effective_config
 from .version import __version__ as pironman5_version
-from .variants import NAME, ID, PRODUCT_VERSION, PERIPHERALS, SYSTEM_DEFAULT_CONFIG, EVENT_MAP
+from .variants import NAME, ID, PRODUCT_VERSION, PERIPHERALS, EVENT_MAP
 from ._constants import CONFIG_PATH, APP_NAME, DEFAULT_DEBUG_LEVEL
 
 from sf_rpi_status import restart_service
@@ -53,17 +53,14 @@ class Pironman5:
 
         # Load config
         # -----------------------------------------
-        self.config = {
-            'system': SYSTEM_DEFAULT_CONFIG,
-        }
-        self.config['system']['debug_level'] = DEFAULT_DEBUG_LEVEL
-
         self.config_path = config_path
+        raw_config = None
         if os.path.exists(self.config_path):
             with open(self.config_path, 'r') as f:
-                config = json.load(f)
-            config = self.upgrade_config(config)
-            self.config = merge_dict(self.config, config)
+                raw_config = json.load(f)
+        self.config = build_effective_config(raw_config)
+        with open(self.config_path, 'w') as f:
+            json.dump(self.config, f, indent=4)
 
         # Set debug level
         # -----------------------------------------
@@ -151,13 +148,6 @@ class Pironman5:
     @log_error
     def set_debug_level(self, level):
         self.log.setLevel(level)
-
-    @log_error
-    def upgrade_config(self, config):
-        ''' upgrade old config to new config converting 'auto' to'system' '''
-        if 'auto' in config:
-            return {'system': config['auto']}
-        return config
 
     @log_error
     def update_config(self, config):

--- a/pironman5/utils.py
+++ b/pironman5/utils.py
@@ -14,6 +14,37 @@ def merge_dict(dict1, dict2):
             new_dict[key] = dict2[key]
     return new_dict
 
+def build_effective_config(raw_config=None):
+    '''
+    Build effective config by merging file overrides onto system defaults.
+
+    Replicates the config assembly logic shared by app startup and CLI.
+    Does NOT write to disk (caller decides whether to persist).
+
+    Args:
+        raw_config: parsed config dict from file (may be None, may have
+                    legacy 'auto' key). Not mutated.
+
+    Returns:
+        dict: effective config {'system': {...}} with defaults + overrides.
+    '''
+    from .variants import SYSTEM_DEFAULT_CONFIG
+    from ._constants import DEFAULT_DEBUG_LEVEL
+
+    config = {
+        'system': SYSTEM_DEFAULT_CONFIG.copy(),
+    }
+    config['system']['debug_level'] = DEFAULT_DEBUG_LEVEL
+
+    if raw_config is not None:
+        # upgrade_config: migrate legacy 'auto' key to 'system'
+        cfg = raw_config
+        if 'auto' in cfg:
+            cfg = {'system': cfg['auto']}
+        config = merge_dict(config, cfg)
+
+    return config
+
 def log_error(func):
     def wrapper(self, *args, **kwargs):
         try:

--- a/tests/test_cli_show_config.py
+++ b/tests/test_cli_show_config.py
@@ -1,0 +1,93 @@
+"""Tests for build_effective_config — shared config assembly used by app & CLI."""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from pironman5.utils import build_effective_config
+
+
+def test_empty_file():
+    """Scenario 1: empty system → full defaults, no crash."""
+    result = build_effective_config({'system': {}})
+    assert 'system' in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    from pironman5._constants import DEFAULT_DEBUG_LEVEL
+    assert result['system']['debug_level'] == DEFAULT_DEBUG_LEVEL
+    print(f"  Empty file: {len(result['system'])} config keys, OK")
+
+
+def test_empty_system():
+    """Scenario 2: {'system': {}} → full defaults."""
+    result = build_effective_config({'system': {}})
+    assert 'system' in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    assert 'data_interval' in result['system']
+    print(f"  Empty system: {len(result['system'])} config keys, OK")
+
+
+def test_partial_override():
+    """Scenario 3: only temperature_unit changed → defaults + override."""
+    result = build_effective_config({'system': {'temperature_unit': 'F'}})
+    assert 'system' in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    assert result['system']['temperature_unit'] == 'F', \
+        f"Expected 'F', got {result['system']['temperature_unit']}"
+    assert 'data_interval' in result['system']
+    assert 'database_retention_days' in result['system']
+    print(f"  Partial override: {len(result['system'])} config keys, temp_unit=F, OK")
+
+
+def test_legacy_auto():
+    """Scenario 4: legacy {'auto': {...}} → migrated to system."""
+    result = build_effective_config({'auto': {'temperature_unit': 'F'}})
+    assert 'system' in result
+    assert 'auto' not in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    assert result['system']['temperature_unit'] == 'F'
+    print(f"  Legacy auto: migrated to system, temp_unit=F, OK")
+
+
+def test_no_file():
+    """Scenario 5: raw_config=None → defaults only."""
+    result = build_effective_config(None)
+    assert 'system' in result
+    assert len(result['system']) >= 17
+    from pironman5._constants import DEFAULT_DEBUG_LEVEL
+    assert result['system']['debug_level'] == DEFAULT_DEBUG_LEVEL
+    print(f"  No file (None): {len(result['system'])} config keys, OK")
+
+
+def test_readonly_input():
+    """build_effective_config must not mutate its input."""
+    original = {'system': {'temperature_unit': 'F'}}
+    copy_before = json.dumps(original)
+    build_effective_config(original)
+    assert json.dumps(original) == copy_before, "Input was mutated!"
+    print("  Read-only (no input mutation): OK")
+
+
+def test_readonly_defaults():
+    """build_effective_config must not mutate SYSTEM_DEFAULT_CONFIG."""
+    from pironman5.variants import SYSTEM_DEFAULT_CONFIG
+    copy_before = json.dumps(SYSTEM_DEFAULT_CONFIG)
+    build_effective_config({'system': {'temperature_unit': 'F'}})
+    assert json.dumps(SYSTEM_DEFAULT_CONFIG) == copy_before, \
+        "SYSTEM_DEFAULT_CONFIG was mutated!"
+    print("  Read-only (defaults not polluted): OK")
+
+
+if __name__ == "__main__":
+    test_empty_file()
+    test_empty_system()
+    test_partial_override()
+    test_legacy_auto()
+    test_no_file()
+    test_readonly_input()
+    test_readonly_defaults()
+    print("\nAll build_effective_config tests passed.")


### PR DESCRIPTION
## Problem

`pironman5 -c` printed the raw config file contents instead of the effective configuration the app actually uses. The app builds its config at startup as variant defaults (`SYSTEM_DEFAULT_CONFIG`) + `DEFAULT_DEBUG_LEVEL`, merged with file overrides (plus legacy `auto` → `system` migration) — but the CLI dumped the file as-is.

Reproduced failure scenarios:

1. **Empty config file** → `json.loads("")` raised `JSONDecodeError` and the CLI exited (the `content == ""` branch was missing an `else`, so the fallback default was overwritten)
2. `{"system": {}}` → printed an empty `system`, while the app uses 18 default keys
3. Partial file (e.g. only `temperature_unit` changed) → printed just that 1 key, missing all defaults
4. Legacy `{"auto": {...}}` → printed `auto` as-is; the app migrates it to `system`

## Fix

Extracted the config assembly into a shared function `build_effective_config()` (`pironman5/utils.py`), used by **both** app startup and the CLI, so future changes stay in sync:

- Starts from `SYSTEM_DEFAULT_CONFIG.copy()` (module-level defaults are never polluted)
- Sets `debug_level` to `DEFAULT_DEBUG_LEVEL`
- Migrates legacy `auto` key to `system`
- Merges file overrides via `merge_dict`
- Read-only: never mutates its input, never writes to disk

- `_cli.py` `-c` now prints the effective config (identical to `Pironman5.__init__` logic) and stays read-only; also fixes the empty-file crash
- `pironman5.py` `__init__` uses the shared function (startup write-back behavior preserved); `upgrade_config` method removed (logic moved into the shared function)

## Files changed

- `pironman5/utils.py` — new `build_effective_config()`
- `pironman5/pironman5.py` — use shared function, remove `upgrade_config`
- `pironman5/_cli.py` — `-c` branch + empty-file fix, use shared function
- `tests/test_cli_show_config.py` — new, tests the real shared function (7 scenarios)

## How to test

Install this branch (select your model from the interactive menu):

```bash
curl -sSL https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/main/pironman5/install.sh | PIRONMAN5_BRANCH=fix/cli-show-effective-config sudo bash
```

Then verify `pironman5 -c` shows the effective config:

```bash
# 1. Empty config file → full effective config (18 keys), no crash
sudo sh -c 'echo -n "" > /opt/pironman5/config.json'
pironman5 -c

# 2. Only one override set → defaults + override merged
sudo sh -c 'echo "{\"system\": {\"temperature_unit\": \"F\"}}" > /opt/pironman5/config.json'
pironman5 -c   # expect temperature_unit: "F" plus all defaults

# 3. Read-only: config file must not change after -c
sudo md5sum /opt/pironman5/config.json
pironman5 -c > /dev/null
sudo md5sum /opt/pironman5/config.json   # same hash

# 4. Unit tests
cd /opt/pironman5/venv 2>/dev/null || true
python3 tests/test_variant_assembly.py
python3 tests/test_cli_show_config.py
```

## Test results

- `tests/test_variant_assembly.py` — all pass
- `tests/test_cli_show_config.py` (7 scenarios) — all pass
- QA integration tests (17 cases) — all pass
