### PR TITLE
fix: sync -c effective config + --cn Gitee mirror fixes to v1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,16 +7,33 @@
 #   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh | sudo bash
 #   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh | sudo bash -s -- --pipower5
 #   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh | sudo bash -s -- --variant base --pipower5 --container
+#   # China mirror (Gitee):
+#   curl -sSL https://gitee.com/sunfounder/pironman5/raw/1.3.x/install.sh | sudo bash -s -- --cn
+#   curl -sSL https://gitee.com/sunfounder/pironman5/raw/1.3.x/install.sh | sudo bash -s -- --cn --variant base
 # (Safe to run directly — interactive prompts read from /dev/tty)
 # ============================================================
 
+# Pre-scan args for --cn (mirror) before downloading the framework,
+# since the framework URL itself needs to use the correct source.
+USE_CN_MIRROR=false
+for _arg in "$@"; do
+    if [ "$_arg" = "--cn" ]; then
+        USE_CN_MIRROR=true
+        break
+    fi
+done
+
 # Source Installer framework — use local path when available (e.g. Docker build),
-# otherwise curl from GitHub.
+# otherwise curl from GitHub (or Gitee mirror with --cn).
 FRAMEWORK_DIR="/tmp/installer-tools"
 if [ -d "$FRAMEWORK_DIR" ]; then
     source "$FRAMEWORK_DIR/installer_1.1.0.sh"
 else
-    INSTALLER_URL="https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/refs/heads/main/tools/installer_1.1.0.sh"
+    if [ "$USE_CN_MIRROR" = true ]; then
+        INSTALLER_URL="https://gitee.com/sunfounder/sunfounder-installer-scripts/raw/main/tools/installer_1.1.0.sh"
+    else
+        INSTALLER_URL="https://raw.githubusercontent.com/sunfounder/sunfounder-installer-scripts/refs/heads/main/tools/installer_1.1.0.sh"
+    fi
     curl -fsSL "$INSTALLER_URL?$(date +%s)" -o installer.sh
     if [ $? -ne 0 ]; then
         echo "Network error, please check your internet connection."
@@ -56,12 +73,14 @@ INSTALL_PLUGIN=""
 NO_AUTOLOGIN=false
 PIPOWER5_BRANCH_ARG=""
 BRANCH_OVERRIDE=""
+# USE_CN_MIRROR already pre-scanned above (before framework download)
 while [ $# -gt 0 ]; do
     case "$1" in
         --pipower5) INSTALL_PIPOWER5=true; INSTALL_PLUGIN="pipower5"; SKIP_MENU=false ;;
         --container) IS_CONTAINER=true; IS_PLAIN_TEXT=true ;;
         --plain-text) IS_PLAIN_TEXT=true ;;
         --no-autologin) NO_AUTOLOGIN=true ;;
+        --cn) USE_CN_MIRROR=true ;;
         --variant=*) ARG_VARIANT="${1#*=}" ;;
         --variant) shift; ARG_VARIANT="$1" ;;
         --plugin) shift; INSTALL_PLUGIN="$1"; INSTALL_PIPOWER5=true; INSTALL_PLUGIN="pipower5" ;;
@@ -178,10 +197,10 @@ fi
 # ============================================================
 # Package Versions
 # ============================================================
-# Fetch pironman5 version from GitHub
+# Fetch pironman5 version from GitHub/Gitee
 PIRONMAN5_VERSION="unknown"
 _fetch_version() {
-    local _vurl="https://raw.githubusercontent.com/sunfounder/pironman5/${1}/pironman5/version.py"
+    local _vurl="${GIT_RAW_BASE}pironman5${GIT_RAW_SEP}${1}/pironman5/version.py"
     local _vraw=$(curl -fsSL "$_vurl" 2>/dev/null) || return 1
     PIRONMAN5_VERSION=$(echo "$_vraw" | awk '/__version__/ { gsub(/[^0-9.]/, ""); print }')
 }
@@ -197,7 +216,19 @@ PM_AUTO_BRANCH="v2"
 DASHBOARD_BRANCH="v2"
 SF_RPI_STATUS_BRANCH="main"
 
-GIT_REPO="https://github.com/sunfounder/"
+# Source base URLs — switch to Gitee mirror with --cn
+# Note: Gitee raw URL format differs from GitHub: needs a /raw/ segment.
+if [ "$USE_CN_MIRROR" = true ]; then
+    GIT_REPO="https://gitee.com/sunfounder/"
+    GIT_RAW_BASE="https://gitee.com/sunfounder/"
+    GIT_RAW_SEP="/raw/"
+    PIPOWER5_DTBO_URL="https://gitee.com/sunfounder/pipower5/raw/main/sunfounder-pipower5.dtbo"
+else
+    GIT_REPO="https://github.com/sunfounder/"
+    GIT_RAW_BASE="https://raw.githubusercontent.com/sunfounder/"
+    GIT_RAW_SEP="/"
+    PIPOWER5_DTBO_URL="https://github.com/sunfounder/pipower5/raw/refs/heads/main/sunfounder-pipower5.dtbo"
+fi
 
 
 
@@ -218,15 +249,19 @@ has() { return 0; }
 echo ""
 # Detect git source (uses framework function, idempotent)
 installer_detect_git_source
+# With --cn, downloads already forced to Gitee — fix the report label
+if [ "$USE_CN_MIRROR" = true ]; then
+    INSTALLER_GIT_SOURCE="Gitee (--cn)"
+fi
 
 echo "========================================="
 echo "  ${product_name}  v${PIRONMAN5_VERSION}"
 echo "  Branch: ${branch}"
 echo "  Source: ${INSTALLER_GIT_SOURCE}"
 echo "  ---------------------------------------"
-# Fetch component versions from GitHub
+# Fetch component versions from GitHub/Gitee
 _fetch_comp_version() {
-    local _url="https://raw.githubusercontent.com/sunfounder/${1}/${2}/$(echo ${1} | sed 's/-/_/g')/version.py"
+    local _url="${GIT_RAW_BASE}${1}${GIT_RAW_SEP}${2}/$(echo ${1} | sed 's/-/_/g')/version.py"
     local _raw=$(curl -fsSL "$_url" 2>/dev/null) || { echo "unknown"; return; }
     echo "$_raw" | awk '/__version__/ { gsub(/[^0-9.]/, ""); print }'
 }
@@ -323,7 +358,7 @@ fi
 # --- Plugin-only install (incremental, only when no --variant given) ---
 if [ "$_PLUGIN_ONLY" = true ]; then
     VENV_PIP="/opt/pironman5/venv/bin/pip3"
-    GIT_REPO="https://github.com/sunfounder/"
+    # GIT_REPO already set to mirror source above (with --cn)
     branch="${BRANCH_OVERRIDE:-1.3.x}"
 
     if [ "$INSTALL_PLUGIN" = "pipower5" ]; then
@@ -374,7 +409,7 @@ if [ "$_PLUGIN_ONLY" = true ]; then
 
         TITLE "Persist device tree overlay"
         RUN "mkdir -p /usr/local/share/sunfounder/overlays" "Create persistent overlay directory"
-        RUN "if [ -f ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; elif [ -f ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; else curl -fsSL https://github.com/sunfounder/pipower5/raw/refs/heads/main/sunfounder-pipower5.dtbo -o /usr/local/share/sunfounder/overlays/sunfounder-pipower5.dtbo; fi" "Persist PiPower5 device tree overlay"
+        RUN "if [ -f ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; elif [ -f ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; else curl -fsSL $PIPOWER5_DTBO_URL -o /usr/local/share/sunfounder/overlays/sunfounder-pipower5.dtbo; fi" "Persist PiPower5 device tree overlay"
         if [ "$IS_CONTAINER" = false ]; then
         RUN "mkdir -p /etc/kernel/postinst.d" "Create postinst.d directory"
         RUN "cp ${PIPOWER5_SRC}/bin/sunfounder-dtbos-hook /etc/kernel/postinst.d/sunfounder-dtbos && chmod +x /etc/kernel/postinst.d/sunfounder-dtbos" "Install kernel postinst hook"
@@ -568,7 +603,7 @@ if [ "$IS_CONTAINER" = false ]; then
         fi
         if [ "$INSTALL_PIPOWER5" = true ]; then
             # Copy pipower5 DT overlay at runtime (after make dtbo has built it)
-            RUN "if [ -f ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ${OVERLAY_PATH}/; elif [ -f ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ${OVERLAY_PATH}/; else curl -fsSL https://github.com/sunfounder/pipower5/raw/refs/heads/main/sunfounder-pipower5.dtbo -o ${OVERLAY_PATH}/sunfounder-pipower5.dtbo; fi" "Copy PiPower5 device tree overlay"
+            RUN "if [ -f ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ${OVERLAY_PATH}/; elif [ -f ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ${OVERLAY_PATH}/; else curl -fsSL $PIPOWER5_DTBO_URL -o ${OVERLAY_PATH}/sunfounder-pipower5.dtbo; fi" "Copy PiPower5 device tree overlay"
         fi
     fi
 fi
@@ -583,7 +618,7 @@ if [ -n "${PM5_OVERLAYS[$variant]}" ] && [ "${PM5_OVERLAYS[$variant]}" != "" ]; 
     RUN "cp ${HOME}/pironman5/overlays/${PM5_OVERLAYS[$variant]} /usr/local/share/sunfounder/overlays/" "Persist ${PM5_OVERLAYS[$variant]}"
 fi
 if [ "$INSTALL_PIPOWER5" = true ]; then
-    RUN "if [ -f ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; elif [ -f ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; else curl -fsSL https://github.com/sunfounder/pipower5/raw/refs/heads/main/sunfounder-pipower5.dtbo -o /usr/local/share/sunfounder/overlays/sunfounder-pipower5.dtbo; fi" "Persist PiPower5 device tree overlay"
+    RUN "if [ -f ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/driver/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; elif [ -f ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo ]; then cp ${PIPOWER5_SRC}/sunfounder-pipower5.dtbo /usr/local/share/sunfounder/overlays/; else curl -fsSL $PIPOWER5_DTBO_URL -o /usr/local/share/sunfounder/overlays/sunfounder-pipower5.dtbo; fi" "Persist PiPower5 device tree overlay"
 fi
 
 if [ "$IS_CONTAINER" = false ]; then

--- a/pironman5/_cli.py
+++ b/pironman5/_cli.py
@@ -11,7 +11,7 @@ from ._launch_browser import run as launch_browser
 from .variants import NAME, PERIPHERALS
 from .pironman5 import Pironman5
 from .version import __version__
-from .utils import is_included, constrain
+from .utils import is_included, constrain, build_effective_config
 
 AVAILABLE_PAGES = []
 AVAILABLE_EMAIL_MODES = []
@@ -171,7 +171,8 @@ def main():
                 content = f.read()
                 if content == '':
                     current_config = {'system': {}}
-                current_config = json.loads(content)
+                else:
+                    current_config = json.loads(content)
             except json.JSONDecodeError:
                 print(f"Invalid config file: {config_path}")
                 quit()
@@ -179,7 +180,8 @@ def main():
     # show config
     # ----------------------------------------
     if args.config:
-        print(json.dumps(current_config, indent=4))
+        effective_config = build_effective_config(current_config)
+        print(json.dumps(effective_config, indent=4))
         quit()
 
     # get or set debug level

--- a/pironman5/pironman5.py
+++ b/pironman5/pironman5.py
@@ -28,9 +28,9 @@ def _format_json(obj, max_level=2, indent=2, _level=0):
 from pm_auto.pm_auto import PMAuto
 from pm_auto import __version__ as pm_auto_version
 from .logger import Logger
-from .utils import merge_dict, log_error
+from .utils import log_error, build_effective_config
 from .version import __version__ as pironman5_version
-from .variants import NAME, ID, PRODUCT_VERSION, PERIPHERALS, SYSTEM_DEFAULT_CONFIG, EVENT_MAP
+from .variants import NAME, ID, PRODUCT_VERSION, PERIPHERALS, EVENT_MAP
 from ._constants import CONFIG_PATH, APP_NAME, DEFAULT_DEBUG_LEVEL
 
 from sf_rpi_status import restart_service
@@ -53,17 +53,14 @@ class Pironman5:
 
         # Load config
         # -----------------------------------------
-        self.config = {
-            'system': SYSTEM_DEFAULT_CONFIG,
-        }
-        self.config['system']['debug_level'] = DEFAULT_DEBUG_LEVEL
-
         self.config_path = config_path
+        raw_config = None
         if os.path.exists(self.config_path):
             with open(self.config_path, 'r') as f:
-                config = json.load(f)
-            config = self.upgrade_config(config)
-            self.config = merge_dict(self.config, config)
+                raw_config = json.load(f)
+        self.config = build_effective_config(raw_config)
+        with open(self.config_path, 'w') as f:
+            json.dump(self.config, f, indent=4)
 
         # Set debug level
         # -----------------------------------------
@@ -151,13 +148,6 @@ class Pironman5:
     @log_error
     def set_debug_level(self, level):
         self.log.setLevel(level)
-
-    @log_error
-    def upgrade_config(self, config):
-        ''' upgrade old config to new config converting 'auto' to'system' '''
-        if 'auto' in config:
-            return {'system': config['auto']}
-        return config
 
     @log_error
     def update_config(self, config):

--- a/pironman5/utils.py
+++ b/pironman5/utils.py
@@ -14,6 +14,37 @@ def merge_dict(dict1, dict2):
             new_dict[key] = dict2[key]
     return new_dict
 
+def build_effective_config(raw_config=None):
+    '''
+    Build effective config by merging file overrides onto system defaults.
+
+    Replicates the config assembly logic shared by app startup and CLI.
+    Does NOT write to disk (caller decides whether to persist).
+
+    Args:
+        raw_config: parsed config dict from file (may be None, may have
+                    legacy 'auto' key). Not mutated.
+
+    Returns:
+        dict: effective config {'system': {...}} with defaults + overrides.
+    '''
+    from .variants import SYSTEM_DEFAULT_CONFIG
+    from ._constants import DEFAULT_DEBUG_LEVEL
+
+    config = {
+        'system': SYSTEM_DEFAULT_CONFIG.copy(),
+    }
+    config['system']['debug_level'] = DEFAULT_DEBUG_LEVEL
+
+    if raw_config is not None:
+        # upgrade_config: migrate legacy 'auto' key to 'system'
+        cfg = raw_config
+        if 'auto' in cfg:
+            cfg = {'system': cfg['auto']}
+        config = merge_dict(config, cfg)
+
+    return config
+
 def log_error(func):
     def wrapper(self, *args, **kwargs):
         try:

--- a/tests/test_cli_show_config.py
+++ b/tests/test_cli_show_config.py
@@ -1,0 +1,93 @@
+"""Tests for build_effective_config — shared config assembly used by app & CLI."""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from pironman5.utils import build_effective_config
+
+
+def test_empty_file():
+    """Scenario 1: empty system → full defaults, no crash."""
+    result = build_effective_config({'system': {}})
+    assert 'system' in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    from pironman5._constants import DEFAULT_DEBUG_LEVEL
+    assert result['system']['debug_level'] == DEFAULT_DEBUG_LEVEL
+    print(f"  Empty file: {len(result['system'])} config keys, OK")
+
+
+def test_empty_system():
+    """Scenario 2: {'system': {}} → full defaults."""
+    result = build_effective_config({'system': {}})
+    assert 'system' in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    assert 'data_interval' in result['system']
+    print(f"  Empty system: {len(result['system'])} config keys, OK")
+
+
+def test_partial_override():
+    """Scenario 3: only temperature_unit changed → defaults + override."""
+    result = build_effective_config({'system': {'temperature_unit': 'F'}})
+    assert 'system' in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    assert result['system']['temperature_unit'] == 'F', \
+        f"Expected 'F', got {result['system']['temperature_unit']}"
+    assert 'data_interval' in result['system']
+    assert 'database_retention_days' in result['system']
+    print(f"  Partial override: {len(result['system'])} config keys, temp_unit=F, OK")
+
+
+def test_legacy_auto():
+    """Scenario 4: legacy {'auto': {...}} → migrated to system."""
+    result = build_effective_config({'auto': {'temperature_unit': 'F'}})
+    assert 'system' in result
+    assert 'auto' not in result
+    assert len(result['system']) >= 17, \
+        f"Expected >=17 keys, got {len(result['system'])}"
+    assert result['system']['temperature_unit'] == 'F'
+    print(f"  Legacy auto: migrated to system, temp_unit=F, OK")
+
+
+def test_no_file():
+    """Scenario 5: raw_config=None → defaults only."""
+    result = build_effective_config(None)
+    assert 'system' in result
+    assert len(result['system']) >= 17
+    from pironman5._constants import DEFAULT_DEBUG_LEVEL
+    assert result['system']['debug_level'] == DEFAULT_DEBUG_LEVEL
+    print(f"  No file (None): {len(result['system'])} config keys, OK")
+
+
+def test_readonly_input():
+    """build_effective_config must not mutate its input."""
+    original = {'system': {'temperature_unit': 'F'}}
+    copy_before = json.dumps(original)
+    build_effective_config(original)
+    assert json.dumps(original) == copy_before, "Input was mutated!"
+    print("  Read-only (no input mutation): OK")
+
+
+def test_readonly_defaults():
+    """build_effective_config must not mutate SYSTEM_DEFAULT_CONFIG."""
+    from pironman5.variants import SYSTEM_DEFAULT_CONFIG
+    copy_before = json.dumps(SYSTEM_DEFAULT_CONFIG)
+    build_effective_config({'system': {'temperature_unit': 'F'}})
+    assert json.dumps(SYSTEM_DEFAULT_CONFIG) == copy_before, \
+        "SYSTEM_DEFAULT_CONFIG was mutated!"
+    print("  Read-only (defaults not polluted): OK")
+
+
+if __name__ == "__main__":
+    test_empty_file()
+    test_empty_system()
+    test_partial_override()
+    test_legacy_auto()
+    test_no_file()
+    test_readonly_input()
+    test_readonly_defaults()
+    print("\nAll build_effective_config tests passed.")


### PR DESCRIPTION
## Summary

Sync two fixes from the frozen 1.3.x line to v1 (the current main branch). These were originally merged to 1.3.x but v1 (newer main line) still lacks them.

1. **`-c` effective config fix** (original PR #96): `pironman5 -c` now shows the effective config (defaults + file merge) via `build_effective_config()` instead of printing raw `config.json`; fixes empty-file JSONDecodeError.
2. **`--cn` Gitee mirror flag** (original PR #97): forces all installer downloads (framework, version probes, git clone, dtbo) to the Gitee mirror for users in mainland China where `raw.githubusercontent.com` is unreliable.

## Changes

- `install.sh`: `--cn` flag, pre-scan args, parameterized `GIT_REPO` / `GIT_RAW_BASE` / `GIT_RAW_SEP` / `PIPOWER5_DTBO_URL`
- `pironman5/_cli.py`, `pironman5/pironman5.py`, `pironman5/utils.py`: effective-config logic
- `tests/test_cli_show_config.py`: tests for `-c`

Cherry-picked cleanly (no conflicts) from `50fd044d` and `72301ef1`.

## How to test

```bash
# Syntax checks
bash -n install.sh

# -c shows effective config (not raw file content)
pironman5 -c

# Empty config file no longer crashes
touch ~/.config/pironman5/config.json && pironman5 -c

# --cn mode install report shows "Source: Gitee (--cn)"
curl -sSL https://gitee.com/sunfounder/pironman5/raw/v1/install.sh | sudo bash -s -- --cn
```

Note: Gitee mirror may lag; the branch is being pushed to Gitee as well.