### PR TITLE
fix: point install commands and default branch to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,38 +25,38 @@ Quick Links:
 ## Installation
 
 ```bash
-curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash
+curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh" | sudo bash
 ```
 
 To install PiPower5 as a plugin alongside Pironman 5, append `--pipower5`:
 
 ```bash
-curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" | sudo bash -s -- --pipower5
+curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh" | sudo bash -s -- --pipower5
 ```
 
 > **For users in mainland China (Gitee mirror):** append `--cn` to download the installer and all resources from Gitee instead of GitHub:
 >
 > ```bash
-> curl -sSL "https://gitee.com/sunfounder/pironman5/raw/1.3.x/install.sh" | sudo bash -s -- --cn
+> curl -sSL "https://gitee.com/sunfounder/pironman5/raw/v1/install.sh" | sudo bash -s -- --cn
 > ```
 >
 > With PiPower5 plugin:
 >
 > ```bash
-> curl -sSL "https://gitee.com/sunfounder/pironman5/raw/1.3.x/install.sh" | sudo bash -s -- --cn --pipower5
+> curl -sSL "https://gitee.com/sunfounder/pironman5/raw/v1/install.sh" | sudo bash -s -- --cn --pipower5
 > ```
 
 > If your system does not support piping directly into `bash`, download the script first and then run it:
 >
 > ```bash
-> curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" -o install.sh
+> curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh" -o install.sh
 > sudo bash install.sh
 > ```
 >
 > With PiPower5 plugin:
 >
 > ```bash
-> curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh" -o install.sh
+> curl -sSL "https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh" -o install.sh
 > sudo bash install.sh --pipower5
 > ```
 

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,12 @@
 # Supports: Pironman 5, Pironman 5 Mini, Pironman 5 Max, Pironman 5 Pro Max, Pironman 5 NAS, Pironman 5 UPS
 #
 # Usage:
-#   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh | sudo bash
-#   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh | sudo bash -s -- --pipower5
-#   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/1.3.x/install.sh | sudo bash -s -- --variant base --pipower5 --container
+#   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh | sudo bash
+#   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh | sudo bash -s -- --pipower5
+#   curl -sSL https://raw.githubusercontent.com/sunfounder/pironman5/v1/install.sh | sudo bash -s -- --variant base --pipower5 --container
 #   # China mirror (Gitee):
-#   curl -sSL https://gitee.com/sunfounder/pironman5/raw/1.3.x/install.sh | sudo bash -s -- --cn
-#   curl -sSL https://gitee.com/sunfounder/pironman5/raw/1.3.x/install.sh | sudo bash -s -- --cn --variant base
+#   curl -sSL https://gitee.com/sunfounder/pironman5/raw/v1/install.sh | sudo bash -s -- --cn
+#   curl -sSL https://gitee.com/sunfounder/pironman5/raw/v1/install.sh | sudo bash -s -- --cn --variant base
 # (Safe to run directly — interactive prompts read from /dev/tty)
 # ============================================================
 
@@ -128,10 +128,10 @@ BRANCH_OVERRIDE="${BRANCH_OVERRIDE:-${PIRONMAN5_BRANCH:-}}"
 # --- Product list (shown in menu) ---
 # Format: "Display Name|variant|branch"
 PRODUCTS=(
-    "Pironman 5|base|1.3.x"
-    "Pironman 5 Max|max|1.3.x"
-    "Pironman 5 Pro Max|pro_max|1.3.x"
-    "Pironman 5 Mini|mini|1.3.x"
+    "Pironman 5|base|v1"
+    "Pironman 5 Max|max|v1"
+    "Pironman 5 Pro Max|pro_max|v1"
+    "Pironman 5 Mini|mini|v1"
 )
 
 # --- Peripherals per variant ---
@@ -359,7 +359,7 @@ fi
 if [ "$_PLUGIN_ONLY" = true ]; then
     VENV_PIP="/opt/pironman5/venv/bin/pip3"
     # GIT_REPO already set to mirror source above (with --cn)
-    branch="${BRANCH_OVERRIDE:-1.3.x}"
+    branch="${BRANCH_OVERRIDE:-v1}"
 
     if [ "$INSTALL_PLUGIN" = "pipower5" ]; then
         TITLE "Clone PiPower 5 source"


### PR DESCRIPTION
README 安装链接和 install.sh 默认分支从 1.3.x 改为 v1（新主分支）：

**README.md**
- GitHub/Gitee 安装 URL：1.3.x → v1（6 处）
- pm_dashboard @1.3.x 保留（该仓库无 v1 分支）

**install.sh**
- 头部 usage 注释 4 处 URL → v1
- PRODUCTS 列表 branch 字段 → v1
- plugin-only 安装默认分支 → v1
- scripts/ 目录 v1 与 1.3.x 一致，DASHBOARD_BRANCH=v2 独立，无破坏

测试命令（合入后）：
`curl -sSL https://gitee.com/sunfounder/pironman5/raw/v1/install.sh | sudo bash -s -- --cn`