### PR TITLE
fix: fetch pironman5 version after GIT_RAW_BASE is set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -194,6 +194,19 @@ else
     IFS='|' read -r product_name variant branch <<< "${PRODUCTS[$selected]}"
 fi
 
+# Source base URLs — switch to Gitee mirror with --cn
+# Note: Gitee raw URL format differs from GitHub: needs a /raw/ segment.
+if [ "$USE_CN_MIRROR" = true ]; then
+    GIT_REPO="https://gitee.com/sunfounder/"
+    GIT_RAW_BASE="https://gitee.com/sunfounder/"
+    GIT_RAW_SEP="/raw/"
+    PIPOWER5_DTBO_URL="https://gitee.com/sunfounder/pipower5/raw/main/sunfounder-pipower5.dtbo"
+else
+    GIT_REPO="https://github.com/sunfounder/"
+    GIT_RAW_BASE="https://raw.githubusercontent.com/sunfounder/"
+    GIT_RAW_SEP="/"
+    PIPOWER5_DTBO_URL="https://github.com/sunfounder/pipower5/raw/refs/heads/main/sunfounder-pipower5.dtbo"
+fi
 # ============================================================
 # Package Versions
 # ============================================================
@@ -201,7 +214,8 @@ fi
 PIRONMAN5_VERSION="unknown"
 _fetch_version() {
     local _vurl="${GIT_RAW_BASE}pironman5${GIT_RAW_SEP}${1}/pironman5/version.py"
-    local _vraw=$(curl -fsSL "$_vurl" 2>/dev/null) || return 1
+    local _vraw
+    _vraw=$(curl -fsSL "$_vurl" 2>/dev/null) || return 1
     PIRONMAN5_VERSION=$(echo "$_vraw" | awk '/__version__/ { gsub(/[^0-9.]/, ""); print }')
 }
 _fetch_version "$branch"
@@ -216,19 +230,6 @@ PM_AUTO_BRANCH="v2"
 DASHBOARD_BRANCH="v2"
 SF_RPI_STATUS_BRANCH="main"
 
-# Source base URLs — switch to Gitee mirror with --cn
-# Note: Gitee raw URL format differs from GitHub: needs a /raw/ segment.
-if [ "$USE_CN_MIRROR" = true ]; then
-    GIT_REPO="https://gitee.com/sunfounder/"
-    GIT_RAW_BASE="https://gitee.com/sunfounder/"
-    GIT_RAW_SEP="/raw/"
-    PIPOWER5_DTBO_URL="https://gitee.com/sunfounder/pipower5/raw/main/sunfounder-pipower5.dtbo"
-else
-    GIT_REPO="https://github.com/sunfounder/"
-    GIT_RAW_BASE="https://raw.githubusercontent.com/sunfounder/"
-    GIT_RAW_SEP="/"
-    PIPOWER5_DTBO_URL="https://github.com/sunfounder/pipower5/raw/refs/heads/main/sunfounder-pipower5.dtbo"
-fi
 
 
 


### PR DESCRIPTION
修复 PR #97 引入的回归：banner 版本号显示为空。

**根因**
- `_fetch_version()` 使用 `${GIT_RAW_BASE}`/`${GIT_RAW_SEP}`，但在 URL base 定义**之前**被调用 → 变量为空 → curl 失败 → 版本号拉不到
- bash 陷阱：`local _vraw=$(curl ...) || return 1` 中 `local` 总是返回 0，`|| return 1` 永不触发 → curl 失败后 `PIRONMAN5_VERSION` 被 awk 清空为 `""`（覆盖初始 `unknown`）→ banner 显示 `v` 后空白

**修复**
1. 把 URL base 定义块（GIT_REPO/GIT_RAW_BASE/GIT_RAW_SEP/PIPOWER5_DTBO_URL）移到 Package Versions 段之前
2. 拆分 `local _vraw` 声明与赋值，让 `|| return 1` 真正生效

**验证**
- `bash -n` 语法通过
- 手动 curl `version.py`：v1 和 1.3.x 均返回 1.3.18

**影响**：1.3.x 分支同样有该 bug（也合了 PR #97），待本 PR 确认后同步。