### PR TITLE
fix: restore ups variant in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,10 +107,10 @@ fi
 # Validate --variant
 if [ -n "$ARG_VARIANT" ]; then
     case "$ARG_VARIANT" in
-        base|mini|max|pro-max|pro_max)
+        base|mini|max|pro-max|pro_max|ups)
             # Normalize pro-max to pro_max for internal key
             [ "$ARG_VARIANT" = "pro-max" ] && ARG_VARIANT="pro_max" ;;
-        *) echo "Invalid variant: $ARG_VARIANT. Valid: base, mini, max, pro-max"; exit 1 ;;
+        *) echo "Invalid variant: $ARG_VARIANT. Valid: base, mini, max, pro-max, ups"; exit 1 ;;
     esac
 fi
 
@@ -132,6 +132,7 @@ PRODUCTS=(
     "Pironman 5 Max|max|v1"
     "Pironman 5 Pro Max|pro_max|v1"
     "Pironman 5 Mini|mini|v1"
+    "Pironman 5 UPS|ups|v1"
 )
 
 # --- Peripherals per variant ---


### PR DESCRIPTION
恢复 ups variant（UPS 规格书 08/04 明确用 `--variant ups` 安装）。

**根因**：06/12 'sync with ups'（319b769b）把 variant 白名单从 `base|mini|max|pro-max|nas|ups|pipower5` 删成 `base|max|pro-max`，但脚本里 `variant=ups → INSTALL_PIPOWER5=true` 的逻辑还在——白名单把 ups 挡在门外。

**改动**
1. `--variant` 校验白名单加 `ups`
2. PRODUCTS 加 `"Pironman 5 UPS|ups|v1"`

**验证**
- `bash -n` 语法通过
- `--variant ups` 校验模拟通过
- PM5_OVERLAYS[ups] 空值安全（`-n` 检查），无 overlay 不阻塞

**范围**：只恢复 ups；pipower5 standalone 是 06/12 有意移除（953d4f12 moved to pipower5 branch），不恢复。NAS 未在 PRODUCTS（NAS 项目尚未到安装阶段）。

**同步**：合入 v1 后需同步 ups 分支（UPS 用户从 ups/install.sh 安装）。