### PR TITLE
fix: upgrade Adafruit-Blinka to 9.2.0 for Pi 5 gpiochip detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -315,7 +315,7 @@ APT_DEPS=$(echo "$APT_DEPS" | tr ' ' '\n' | awk 'NF' | sort -u | tr '\n' ' ')
 # -- Pip dependencies (installed into venv) --
 PIP_DEPS="pip setuptools build requests psutil"
 if has "ws2812"; then
-    PIP_DEPS="$PIP_DEPS adafruit-circuitpython-neopixel-spi adafruit_platformdetect Adafruit-Blinka==8.59.0 rpi.lgpio adafruit-circuitpython-typing 'Adafruit-PureIO>=1.1.7' 'pyftdi>=0.40.0'"
+    PIP_DEPS="$PIP_DEPS adafruit-circuitpython-neopixel-spi adafruit_platformdetect Adafruit-Blinka==9.2.0 rpi.lgpio adafruit-circuitpython-typing 'Adafruit-PureIO>=1.1.7' 'pyftdi>=0.40.0'"
 fi
 if has "oled"; then
     PIP_DEPS="$PIP_DEPS Pillow smbus2"


### PR DESCRIPTION
## Problem

Adafruit-Blinka 8.59.0 derives the GPIO chip number in lgpio_pin.py with
int(dev.name[-1]), which only reads the last character of the device name
(e.g. gpiochip4 -> 4, but gpiochip12 -> 2). On Raspberry Pi 5 systems whose
gpiochip number has more than one digit this selects the wrong chip, and the
OLED / RGB peripherals stop responding.

Adafruit-Blinka 9.2.0 fixes this by parsing the full chip number
(int(dev.name[len("gpiochip"):])) and opening it with gpiochip_open(chip_id).

Related upstream issue: https://github.com/adafruit/Adafruit_Blinka/issues/966

## Change

Bump the pinned Adafruit-Blinka from 8.59.0 to 9.2.0 in install.sh.

## How to test

On a Raspberry Pi 5 (ideally one that reproduces the gpiochip misdetection,
e.g. after a 6.12 kernel update with an external SSD):

    sudo /opt/pironman5/venv/bin/pip3 install --upgrade adafruit-blinka==9.2.0
    sudo systemctl restart pironman5.service

Confirm the OLED and RGB respond correctly. Alternatively, re-run the installer
and verify the venv ends up with Adafruit-Blinka 9.2.0 installed and the
OLED / RGB still work.
